### PR TITLE
Add GPT-4o content generator support

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { createContentGenerator, AuthType } from './contentGenerator.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { GoogleGenAI } from '@google/genai';
+import { GPT4oContentGenerator } from './gpt4oContentGenerator.js';
 
 vi.mock('../code_assist/codeAssist.js');
 vi.mock('@google/genai');
@@ -46,5 +47,17 @@ describe('contentGenerator', () => {
       },
     });
     expect(generator).toBe((mockGenerator as GoogleGenAI).models);
+  });
+
+  it('should create a GPT4oContentGenerator', async () => {
+    vi.spyOn(GPT4oContentGenerator.prototype, 'generateContent');
+    const generator = await createContentGenerator({
+      model: 'gpt-4o',
+      authType: AuthType.CUSTOM_GPT4O,
+      customUrl: 'http://localhost',
+      customAuthHeaderName: 'X-Test',
+      customAuthToken: 'token',
+    });
+    expect(generator).toBeInstanceOf(GPT4oContentGenerator);
   });
 });

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -13,6 +13,7 @@ import {
   EmbedContentParameters,
   GoogleGenAI,
 } from '@google/genai';
+import { GPT4oContentGenerator } from './gpt4oContentGenerator.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 import { getEffectiveModel } from './modelCheck.js';
@@ -38,6 +39,7 @@ export enum AuthType {
   LOGIN_WITH_GOOGLE_PERSONAL = 'oauth-personal',
   USE_GEMINI = 'gemini-api-key',
   USE_VERTEX_AI = 'vertex-ai',
+  CUSTOM_GPT4O = 'custom-gpt4o',
 }
 
 export type ContentGeneratorConfig = {
@@ -45,6 +47,12 @@ export type ContentGeneratorConfig = {
   apiKey?: string;
   vertexai?: boolean;
   authType?: AuthType | undefined;
+  /** Custom endpoint for GPT-4o or other models. */
+  customUrl?: string;
+  /** Name of the custom authentication header. */
+  customAuthHeaderName?: string;
+  /** Token value for the custom authentication header. */
+  customAuthToken?: string;
 };
 
 export async function createContentGeneratorConfig(
@@ -56,6 +64,9 @@ export async function createContentGeneratorConfig(
   const googleApiKey = process.env.GOOGLE_API_KEY;
   const googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
   const googleCloudLocation = process.env.GOOGLE_CLOUD_LOCATION;
+  const customUrl = process.env.GPT4O_ENDPOINT;
+  const customHeaderName = process.env.GPT4O_AUTH_HEADER_NAME;
+  const customToken = process.env.GPT4O_AUTH_TOKEN;
 
   // Use runtime model from config if available, otherwise fallback to parameter or default
   const effectiveModel = config?.getModel?.() || model || DEFAULT_GEMINI_MODEL;
@@ -97,6 +108,18 @@ export async function createContentGeneratorConfig(
     return contentGeneratorConfig;
   }
 
+  if (
+    authType === AuthType.CUSTOM_GPT4O &&
+    customUrl &&
+    customHeaderName &&
+    customToken
+  ) {
+    contentGeneratorConfig.customUrl = customUrl;
+    contentGeneratorConfig.customAuthHeaderName = customHeaderName;
+    contentGeneratorConfig.customAuthToken = customToken;
+    return contentGeneratorConfig;
+  }
+
   return contentGeneratorConfig;
 }
 
@@ -124,6 +147,17 @@ export async function createContentGenerator(
     });
 
     return googleGenAI.models;
+  }
+
+  if (config.authType === AuthType.CUSTOM_GPT4O) {
+    if (!config.customUrl || !config.customAuthHeaderName || !config.customAuthToken) {
+      throw new Error('Missing custom GPT-4o configuration.');
+    }
+    return new GPT4oContentGenerator({
+      url: config.customUrl,
+      authHeaderName: config.customAuthHeaderName,
+      authToken: config.customAuthToken,
+    });
   }
 
   throw new Error(

--- a/packages/core/src/core/gpt4oContentGenerator.ts
+++ b/packages/core/src/core/gpt4oContentGenerator.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ContentGenerator,
+  GenerateContentParameters,
+  GenerateContentResponse,
+  CountTokensParameters,
+  CountTokensResponse,
+  EmbedContentParameters,
+  EmbedContentResponse,
+} from '@google/genai';
+
+/** Options for the GPT-4o content generator. */
+export interface GPT4oContentGeneratorOptions {
+  /** Endpoint URL for the GPT-4o API. */
+  url: string;
+  /** Name of the authentication header (e.g. "Authorization"). */
+  authHeaderName: string;
+  /** Token to be used for authentication. */
+  authToken: string;
+}
+
+/**
+ * A simple ContentGenerator implementation that proxies requests to a GPT-4o
+ * compatible endpoint. Input messages are converted to OpenAI's chat format and
+ * the response is mapped back to a {@link GenerateContentResponse} structure.
+ */
+export class GPT4oContentGenerator implements ContentGenerator {
+  constructor(private readonly opts: GPT4oContentGeneratorOptions) {}
+
+  private partsToText(parts: any[]): string {
+    return parts
+      .map((p) => {
+        if (typeof p === 'string') return p;
+        if (p && typeof p.text === 'string') return p.text;
+        return '';
+      })
+      .join('');
+  }
+
+  private contentToMessage(content: any): { role: string; content: string } {
+    const role = content.role === 'model' ? 'assistant' : content.role;
+    return {
+      role,
+      content: this.partsToText(content.parts || []),
+    };
+  }
+
+  private toMessages(req: GenerateContentParameters): any[] {
+    const items = req.contents as any;
+    if (Array.isArray(items) && items.length && 'role' in items[0]) {
+      return items.map((c: any) => this.contentToMessage(c));
+    }
+    if (Array.isArray(items)) {
+      return [{ role: 'user', content: this.partsToText(items) }];
+    }
+    if ('parts' in items) {
+      return [this.contentToMessage(items)];
+    }
+    return [{ role: 'user', content: this.partsToText([items]) }];
+  }
+
+  async generateContent(
+    req: GenerateContentParameters,
+  ): Promise<GenerateContentResponse> {
+    const messages = this.toMessages(req);
+    const body = {
+      model: req.model,
+      messages,
+      temperature: req.config?.temperature,
+      top_p: req.config?.topP,
+      max_tokens: req.config?.maxOutputTokens,
+      stream: false,
+    };
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      [this.opts.authHeaderName]: this.opts.authToken,
+    };
+    const response = await fetch(this.opts.url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: req.config?.abortSignal,
+    });
+    const json = await response.json();
+    const text = json.choices?.[0]?.message?.content ?? '';
+    const candidate = {
+      content: { role: 'model', parts: [{ text }] },
+    };
+    return { candidates: [candidate] } as GenerateContentResponse;
+  }
+
+  async generateContentStream(
+    req: GenerateContentParameters,
+  ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    const resp = await this.generateContent(req);
+    return (async function* () {
+      yield resp;
+    })();
+  }
+
+  async countTokens(
+    _req: CountTokensParameters,
+  ): Promise<CountTokensResponse> {
+    // Token counting is not supported; return undefined.
+    return {} as CountTokensResponse;
+  }
+
+  async embedContent(
+    _req: EmbedContentParameters,
+  ): Promise<EmbedContentResponse> {
+    // Embeddings are not supported.
+    return {} as EmbedContentResponse;
+  }
+}
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from './core/turn.js';
 export * from './core/geminiRequest.js';
 export * from './core/coreToolScheduler.js';
 export * from './core/nonInteractiveToolExecutor.js';
+export * from './core/gpt4oContentGenerator.js';
 
 export * from './code_assist/codeAssist.js';
 export * from './code_assist/oauth2.js';


### PR DESCRIPTION
## Summary
- add GPT4oContentGenerator class for custom LLM endpoints
- extend ContentGenerator to support custom GPT-4o auth type and config
- export new generator
- test creation of GPT4oContentGenerator

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d4774e72c83309e4d7df39e8243ea